### PR TITLE
Allow custom vmIds

### DIFF
--- a/src/server/vmManageRoutes.js
+++ b/src/server/vmManageRoutes.js
@@ -71,8 +71,8 @@ const cloneAndRunVM = co.wrap(function *(application, vmNameOrId, clonedName, sn
 const addVM = co.wrap(function * (ctx) {
     const application = ctx.application;
     const vms = application.vms;
-    const vmId = createId();
     const body = yield parse.json(ctx);
+    const vmId = body.name ? body.name : createId();
     const params = {
         closeOnFailedCalibration: body.closeOnFailedCalibration
     };


### PR DESCRIPTION
**Description:**

Allow for a custom `vmId` when performing a clone.

**Example:**
```
curl -X POST 'http://toto:secret@localhost:7778/' -d '{"clone":"MyMachineName", "snapshot": "MySnapshotName", "name": "MyCloneName"}'
```